### PR TITLE
Update cmake to pass along console_bridge

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,30 +1,29 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rosconsole_bridge)
 
-find_package(catkin COMPONENTS rosconsole REQUIRED)
-include_directories(${catkin_INCLUDE_DIRS})
+find_package(catkin COMPONENTS rosconsole console_bridge REQUIRED)
+
+include_directories(include ${catkin_INCLUDE_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})
 
 catkin_package(
   LIBRARIES ${PROJECT_NAME}
   INCLUDE_DIRS include
-  )
+  CATKIN_DEPENDS console_bridge rosconsole
+)
 
-include_directories(include)
+add_library(${PROJECT_NAME} src/bridge.cpp)
 
-find_package(console_bridge REQUIRED)
-include_directories(${console_bridge_INCLUDE_DIR})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
-add_library(${PROJECT_NAME}
-  src/bridge.cpp)
+install(
+  TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+)
 
-target_link_libraries(${PROJECT_NAME} ${console_bridge_LIBRARIES} ${catkin_LIBRARIES})
-
-install(TARGETS ${PROJECT_NAME}
-        ARCHIVE DESTINATION lib
-        LIBRARY DESTINATION lib)
-
-install(DIRECTORY include/
-        DESTINATION include
-        FILES_MATCHING PATTERN "*.h")
-
+install(
+  DIRECTORY include/
+  DESTINATION include
+  FILES_MATCHING PATTERN "*.h"
+)


### PR DESCRIPTION
It was not passing along rosconsole or console_bridge correctly.

It was find_package'ing after catkin_package.

It was not treating console_bridge like a catkin dependency.
