### PR TITLE
fixing catkin as a buildtool dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -13,7 +13,7 @@
   <url type="bugtracker">https://github.com/ros/rosconsole_bridge/issues</url>
   <url type="repository">https://github.com/ros/rosconsole_bridge</url>
   
-  <build_depend>catkin</build_depend>
+  <buildtool_depend>catkin</buildtool_depend>
   <build_depend>rosconsole</build_depend>
   <build_depend>console_bridge</build_depend>
 


### PR DESCRIPTION
The catkin dependency should be a buildtool not a build depend.
