### PR TITLE
fix: on destruction OutputHandlerROS should restore the previous handler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,3 +27,7 @@ install(
 install(
   DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+
+if(CATKIN_ENABLE_TESTING)
+  add_subdirectory(test)
+endif()

--- a/include/rosconsole_bridge/bridge.h
+++ b/include/rosconsole_bridge/bridge.h
@@ -46,6 +46,7 @@ class OutputHandlerROS : public console_bridge::OutputHandler
 {
 public:
   OutputHandlerROS(void);
+  ~OutputHandlerROS();
   virtual void log(const std::string &text, console_bridge::LogLevel level, const char *filename, int line);
 };
 

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -45,6 +45,10 @@ OutputHandlerROS::OutputHandlerROS(void) : OutputHandler()
 {
 }
 
+OutputHandlerROS::~OutputHandlerROS(void) {
+  console_bridge::restorePreviousOutputHandler();
+}
+
 void OutputHandlerROS::log(const std::string &text, console_bridge::LogLevel level, const char *filename, int line)
 {
   std::string prefix;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,4 @@
+# How can we ensure that the binary goes to build dir only, not devel dir?
+add_executable(cleanup cleanup.cpp)
+target_link_libraries(cleanup rosconsole_bridge)
+add_test(cleanup COMMAND cleanup)

--- a/test/cleanup.cpp
+++ b/test/cleanup.cpp
@@ -1,0 +1,22 @@
+#include <console_bridge/console.h>
+#include <rosconsole_bridge/bridge.h>
+
+struct A {
+  A(const char* hint) {
+    logWarn("initializing class: %s", hint);
+  }
+  ~A() {
+    logWarn("destroying class");
+  }
+};
+
+// destructor of static instance should use the original output handler
+static A a("static");
+
+REGISTER_ROSCONSOLE_BRIDGE;
+
+int main(int argc, char **argv)
+{
+  A a("local");
+  return 0;
+}


### PR DESCRIPTION
Because the destructor of OutputHandlerROS didn't restore the previous default handler, the example `test/cleanup.cpp` crashes with:

```
pure virtual method called
terminate called without an active exception
Aborted (core dumped)
```
