### PR TITLE
fix linking order

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ catkin_package(
 
 add_library(${PROJECT_NAME} src/bridge.cpp)
 
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${console_bridge_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${console_bridge_LIBRARIES} ${catkin_LIBRARIES})
 
 install(
   TARGETS ${PROJECT_NAME}


### PR DESCRIPTION
First link console_bridge then other ros libs to enable clean linking
against an own version of console_bridge.

Otherwise some default console_bridge is found due to the argument -lconsole_bridge:

rhaschke@idas:build [remotes/origin/indigo-devel]m$ make VERBOSE=1
...
**Linking CXX shared library devel/lib/librosconsole_bridge.so**
/usr/bin/cmake -E cmake_link_script CMakeFiles/rosconsole_bridge.dir/link.txt --verbose=1
/usr/bin/c++  -fPIC -march=core2 -mtune=generic -O0 -O3 -Wno-deprecated-declarations -O2 -g -DNDEBUG   -shared -Wl,-soname,librosconsole_bridge.so -o devel/lib/librosconsole_bridge.so CMakeFiles/rosconsole_bridge.dir/src/bridge.cpp.o  -L/opt/ros/indigo/lib /opt/ros/indigo/lib/librosconsole.so /opt/ros/indigo/lib/librosconsole_log4cxx.so /opt/ros/indigo/lib/librosconsole_backend_interface.so -llog4cxx -lboost_regex /opt/ros/indigo/lib/librostime.so -lboost_date_time /opt/ros/indigo/lib/libcpp_common.so -lboost_system -lboost_thread -lpthread **-lconsole_bridge** /vol/famula/nightly/ros/indigo/lib/x86_64-linux-gnu/libconsole_bridge.so -Wl,-rpath,/vol/famula/nightly/ros/indigo/lib/x86_64-linux-gnu:/opt/ros/indigo/lib: 
...
Linking CXX executable ../devel/lib/rosconsole_bridge/cleanup
...
_/usr/bin/ld: warning: libconsole_bridge.so.0.2, needed by ../devel/lib/librosconsole_bridge.so, may conflict with libconsole_bridge.so.0.3_
