### PR TITLE
Feature/support multiple activation and deactivation

### DIFF
--- a/include/rosconsole_bridge/bridge.h
+++ b/include/rosconsole_bridge/bridge.h
@@ -50,6 +50,9 @@ public:
   virtual void log(const std::string &text, console_bridge::LogLevel level, const char *filename, int line);
 };
 
+void activate();
+void deactivate();
+
 struct RegisterOutputHandlerProxy
 {
   RegisterOutputHandlerProxy(void);

--- a/test/cleanup.cpp
+++ b/test/cleanup.cpp
@@ -1,28 +1,11 @@
-#include <console_bridge/console.h>
 #include <rosconsole_bridge/bridge.h>
-#include <string>
-
-struct A {
-  A(const char* hint) :  hint_(hint) {
-    logWarn("initializing class: %s", hint);
-  }
-  ~A() {
-    if(hint_ == "static"){ // mimic original behavior
-      rosconsole_bridge::deactivate();
-    }
-    logWarn("destroying class: %s", hint_.c_str());
-  }
-private:
-  std::string hint_;
-};
-
-// destructor of static instance should use the original output handler
-static A a("static");
 
 REGISTER_ROSCONSOLE_BRIDGE;
 
 int main(int argc, char **argv)
 {
-  A a("local");
+  logWarn("This warning should be delivered through rosconsole");
+  rosconsole_bridge::deactivate();
+  logWarn("This warning should be delivered through the original console_bridge output handler");
   return 0;
 }

--- a/test/cleanup.cpp
+++ b/test/cleanup.cpp
@@ -1,13 +1,19 @@
 #include <console_bridge/console.h>
 #include <rosconsole_bridge/bridge.h>
+#include <string>
 
 struct A {
-  A(const char* hint) {
+  A(const char* hint) :  hint_(hint) {
     logWarn("initializing class: %s", hint);
   }
   ~A() {
-    logWarn("destroying class");
+    if(hint_ == "static"){ // mimic original behavior
+      rosconsole_bridge::deactivate();
+    }
+    logWarn("destroying class: %s", hint_.c_str());
   }
+private:
+  std::string hint_;
 };
 
 // destructor of static instance should use the original output handler


### PR DESCRIPTION
This supports linking multiple `REGISTER_ROSCONSOLE_BRIDGE;` together and therefore enables ROS libraries to take care of this for non-ROS libraries they might depend on without risk.

This is one possible first step to improve on issue #12 .

The extra complexity to support deactivation is not necessary.
Currently it is just used to allow the "cleanup" test to remain partial functional. Admittedly this way it does not serve as much of a purpose as before. The problem is the introduced singleton that takes care of disabling the output handler at program termination. I don't know an easy way to test this from within the program without extra complexity in the library itself. However, the standard guarantees the destruction of static locals within the program termination phase - as far as I know. And the deactivate functionality is still successfully tested:

> [ WARN] [1501317381.498355918]: This warning should be served through rosconsole
> Warning: This warning should be served through the original console_bridge output handler
         at line 9 in .../rosconsole_bridge/test/cleanup.cpp

(its output on my system)
