### PR TITLE
Fix static destruction ordering issue on macOS

### DIFF
--- a/include/rosconsole_bridge/bridge.h
+++ b/include/rosconsole_bridge/bridge.h
@@ -46,13 +46,13 @@ class OutputHandlerROS : public console_bridge::OutputHandler
 {
 public:
   OutputHandlerROS(void);
-  ~OutputHandlerROS();
   virtual void log(const std::string &text, console_bridge::LogLevel level, const char *filename, int line);
 };
 
 struct RegisterOutputHandlerProxy
 {
   RegisterOutputHandlerProxy(void);
+  ~RegisterOutputHandlerProxy();
 };
 
 }

--- a/src/bridge.cpp
+++ b/src/bridge.cpp
@@ -45,10 +45,6 @@ OutputHandlerROS::OutputHandlerROS(void) : OutputHandler()
 {
 }
 
-OutputHandlerROS::~OutputHandlerROS(void) {
-  console_bridge::restorePreviousOutputHandler();
-}
-
 void OutputHandlerROS::log(const std::string &text, console_bridge::LogLevel level, const char *filename, int line)
 {
   std::string prefix;
@@ -128,6 +124,11 @@ RegisterOutputHandlerProxy::RegisterOutputHandlerProxy(void)
 
   // we want the output level to be decided by rosconsole, so we bring all messages to rosconsole
   console_bridge::setLogLevel(console_bridge::CONSOLE_BRIDGE_LOG_DEBUG);
+}
+
+RegisterOutputHandlerProxy::~RegisterOutputHandlerProxy()
+{
+  console_bridge::restorePreviousOutputHandler();
 }
 
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
 # How can we ensure that the binary goes to build dir only, not devel dir?
 add_executable(cleanup cleanup.cpp)
 target_link_libraries(cleanup rosconsole_bridge)
-add_test(cleanup COMMAND cleanup)
+add_test(NAME cleanup COMMAND cleanup)


### PR DESCRIPTION
This is a follow-up of #10 (fix: on destruction OutputHandlerROS should restore the previous handler).

### Problem Description
While for Linux the proposed fix works nicely and avoids the pure virtual method call demonstrated by the `cleanup` unit test, on macOS the added call to `console_bridge::restorePreviousOutputHandler()` in the destructor of `OutputHandlerROS` triggers an exception because [this mutex](https://github.com/ros/console_bridge/blob/master/src/console.cpp#L60) in `console_bridge`'s [`static DefaultHandler DOH`](https://github.com/ros/console_bridge/blob/master/src/console.cpp#L69) struct has already been destructed when the call to `console_bridge::restorePreviousOutputHandler()` tries to lock it during the static destruction of [RegisterOutputHandlerProxy](https://github.com/rhaschke/rosconsole_bridge/blob/04d37b29f181696588f1780507e1a73fcab21cb5/src/bridge.cpp#L48]).

```
libc++abi.dylib: terminating with uncaught exception of type std::__1::system_error: mutex lock failed: Invalid argument
Process 13839 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGABRT
    frame #0: 0x00007fffb664fd42 libsystem_kernel.dylib`__pthread_kill + 10
libsystem_kernel.dylib`__pthread_kill:
->  0x7fffb664fd42 <+10>: jae    0x7fffb664fd4c            ; <+20>
    0x7fffb664fd44 <+12>: movq   %rax, %rdi
    0x7fffb664fd47 <+15>: jmp    0x7fffb6648caf            ; cerror_nocancel
    0x7fffb664fd4c <+20>: retq
Target 0: (rviz) stopped.
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGABRT
  * frame #0: 0x00007fffb664fd42 libsystem_kernel.dylib`__pthread_kill + 10
    frame #1: 0x00007fffb673d457 libsystem_pthread.dylib`pthread_kill + 90
    frame #2: 0x00007fffb65b5420 libsystem_c.dylib`abort + 129
    frame #3: 0x00007fffb510994a libc++abi.dylib`abort_message + 266
    frame #4: 0x00007fffb512ec17 libc++abi.dylib`default_terminate_handler() + 243
    frame #5: 0x00007fffb5c3d713 libobjc.A.dylib`_objc_terminate() + 124
    frame #6: 0x00007fffb512bd49 libc++abi.dylib`std::__terminate(void (*)()) + 8
    frame #7: 0x00007fffb512bdc3 libc++abi.dylib`std::terminate() + 51
    frame #8: 0x000000010229a11b librosconsole_bridge.dylib`__clang_call_terminate + 11
    frame #9: 0x000000010229a13d librosconsole_bridge.dylib`rosconsole_bridge::OutputHandlerROS::~OutputHandlerROS() + 29
    frame #10: 0x00007fffb65b6178 libsystem_c.dylib`__cxa_finalize_ranges + 332
    frame #11: 0x00007fffb65b64b2 libsystem_c.dylib`exit + 55
    frame #12: 0x00007fffb652123c libdyld.dylib`start + 8
(lldb)
```
(after quitting rviz with ROS kinetic built from source on macOS Sierra 10.12, with system dependencies installed from HomeBrew, with console_bridge 0.4.0 and rosconsole_bridge version 0.5.1)

I could not reproduce this problem for "normal" executables that only link statically to dynamic libraries, but the exception is triggered consistently if the application loaded libraries dynamically at run-time (`dlopen()`, e.g. through pluginlib) that directly or indirectly link to `librosconsole_bridge.dylib`.

The root cause is likely the different ordering of Linux and Darwin during the static initialization and destruction phase. While Linux initializes all global symbols right after a dynamic library has been loaded, Darwin only initializes them on first use. Apparently that is what is called "[deferred dynamic initialization](https://en.cppreference.com/w/cpp/language/initialization#Deferred_dynamic_initialization)" in [1], which is allowed by the C++ standard [2]. The destruction happens in strictly reverse order of initialization in both cases, where the completion of the constructor or dynamic initialization is the synchronization point [3].

If the construction of [OutputHandlerROS](https://github.com/rhaschke/rosconsole_bridge/blob/04d37b29f181696588f1780507e1a73fcab21cb5/src/bridge.cpp#L48]) called during static initialization of [oh_ros](https://github.com/rhaschke/rosconsole_bridge/blob/04d37b29f181696588f1780507e1a73fcab21cb5/src/bridge.cpp#L126) from the [constructor of RegisterOutputHandlerProxy]([https://github.com/rhaschke/rosconsole_bridge/blob/04d37b29f181696588f1780507e1a73fcab21cb5/src/bridge.cpp#L124) finishes before the first call to [getDOH()](https://github.com/ros/console_bridge/blob/master/src/console.cpp#L67), which in turn initializes the mutex as part of the static initialization of [DefaultOutputHandler DOH](https://github.com/ros/console_bridge/blob/master/src/console.cpp#L69), the mutex also gets destroyed before the [destruction of oh_ros](https://github.com/rhaschke/rosconsole_bridge/blob/04d37b29f181696588f1780507e1a73fcab21cb5/src/bridge.cpp#L48), which calls into [console_bridge::restorePreviousOutputHandler](https://github.com/ros/console_bridge/blob/master/src/console.cpp#L88) and tries to lock it.

### Proposed patch
The solution is to make sure that the output handler is restored during the destruction of exactly the same object that installed a new one, namely `RegisterOutputHandlerProxy`. If it's not the constructor of `OutputHandlerROS` that calls `console_bridge::useOutputHandler(this)`, it should also not be the destructors responsibility to call `console_bridge::restorePreviousOutputHandler()`.

Note that there might be more than one instance of `RegisterOutputHandlerProxy` in a single process because it can be instantiated once for every compilation unit that included the [REGISTER_ROSCONSOLE_BRIDGE](https://github.com/rhaschke/rosconsole_bridge/blob/04d37b29f181696588f1780507e1a73fcab21cb5/include/rosconsole_bridge/bridge.h#L60) macro that defines the symbol `rosconsole_bridge::RegisterOutputHandlerProxy __register_rosconsole_output_handler_proxy`, depending on whether it is loaded with [RTLD_GLOBAL](http://pubs.opengroup.org/onlinepubs/7908799/xsh/dlopen.html) or not, and they refer to either the same or a different instance of [static OutputHandlerROS oh_ros](https://github.com/rhaschke/rosconsole_bridge/blob/04d37b29f181696588f1780507e1a73fcab21cb5/src/bridge.cpp#L126).

### ABI compatibility (tested on Xenial only)
I think the same reasoning about ABI-compatibility as in https://github.com/ros/rosconsole_bridge/pull/10#discussion_r59419426 applies to this patch, too:
```
$ abi-compliance-checker -l rosconsole_bridge -old rosconsole_bridge-0.5.1.dump -new rosconsole_bridge-fix.dump 
preparation, please wait ...
WARNING: version number #1 is not set (use --v1=NUM option)
WARNING: version number #2 is not set (use --v2=NUM option)
comparing ABIs ...
comparing APIs ...
creating compatibility report ...
result: COMPATIBLE
total "Binary" compatibility problems: 0, warnings: 0
total "Source" compatibility problems: 0, warnings: 0
see detailed report:
  compat_reports/rosconsole_bridge/X_to_Y/compat_report.html
```

But as the definition of `RegisterOutputHandlerProxy` has been changed, which is actually instantiated in another compilation unit (e.g. `liburdf.so`), we also have to test this one:
```
$ abi-compliance-checker -l urdf -old urdf-0.5.1.dump -new urdf-fix.dump 
preparation, please wait ...
WARNING: version number #1 is not set (use --v1=NUM option)
WARNING: version number #2 is not set (use --v2=NUM option)
comparing ABIs ...
comparing APIs ...
creating compatibility report ...
result: COMPATIBLE
total "Binary" compatibility problems: 0, warnings: 0
total "Source" compatibility problems: 0, warnings: 0
see detailed report:
  compat_reports/urdf/X_to_Y/compat_report.html
```

That being said, even if ABI compatible, if only rosconsole_bridge would be recompiled/upgraded, but not the compilation unit that expands the [REGISTER_ROSCONSOLE_BRIDGE](https://github.com/rhaschke/rosconsole_bridge/blob/04d37b29f181696588f1780507e1a73fcab21cb5/include/rosconsole_bridge/bridge.h#L60) macro and instantiates `RegisterOutputHandlerProxy`, none of the two destructors would be called which might result in the pure virtual method call during static destruction again.

### Unit test
The [add_test()](https://cmake.org/cmake/help/v3.0/command/add_test.html) call in [test/CMakeLists.txt:4](https://github.com/meyerj/rosconsole_bridge/blob/ef57ce056c886566720d524e9db0104d743d9ab1/test/CMakeLists.txt#L4) was missing a `NAME` keyword, which is why it always failed for me when running through the target `test` generated by cmake, because it tried to execute a command called `COMMAND`. Also note that the unit test is not using [catkin's test infrastructure](http://docs.ros.org/api/catkin/html/howto/format2/run_tests.html) which defines the targets `tests` and `run_tests` and only provides macros for nosetests and gtest. It will not run automatically on `make run_tests` or [on the ROS build farm](http://build.ros.org/job/Kdev__rosconsole_bridge__ubuntu_xenial_amd64/8/console). In order to fix that catkin should provide a macro like `catkin_add_test()` that is not specific to a certain testing library and can execute arbitrary commands, but which integrates with its `run_tests` target.

### References
[1] https://en.cppreference.com/w/cpp/language/initialization#Deferred_dynamic_initialization
[2] http://eel.is/c++draft/basic.start.dynamic#4
[3] http://eel.is/c++draft/basic.start#term-3

