### PR TITLE
hide `struct A` from doxygen

### DIFF
--- a/test/cleanup.cpp
+++ b/test/cleanup.cpp
@@ -7,6 +7,7 @@
   #define CONSOLE_BRIDGE_logWarn logWarn
 #endif
 
+/// @cond IGNORE_THIS
 struct A {
   A(const char* hint) {
     CONSOLE_BRIDGE_logWarn("initializing class: %s", hint);
@@ -15,6 +16,7 @@ struct A {
     CONSOLE_BRIDGE_logWarn("destroying class");
   }
 };
+/// @endcond
 
 // destructor of static instance should use the original output handler
 static A a("static");


### PR DESCRIPTION
The throwaway `struct A` created in this test is getting picked up by doxygen and linked wherever the word "A" occurs--for instace, the parameter explanations [in this MoveIt doc](https://docs.ros.org/en/api/moveit_ros_planning/html/classplanning__scene__monitor_1_1PlanningSceneMonitor.html#a06558bd646e8fe960b1a6a523ec2a576). This PR hides the struct from doxygen.